### PR TITLE
Remove special handling of empty string resources

### DIFF
--- a/datasource/src/main/scala/quasar/physical/s3/S3Datasource.scala
+++ b/datasource/src/main/scala/quasar/physical/s3/S3Datasource.scala
@@ -21,7 +21,6 @@ import quasar.api.resource.ResourcePath.{Leaf, Root}
 import quasar.api.resource.{ResourceName, ResourcePath, ResourcePathType}
 import quasar.connector.{MonadResourceErr, ParsableType, QueryResult, ResourceError}
 import quasar.connector.datasource.LightweightDatasource
-import quasar.contrib.pathy.APath
 import quasar.contrib.scalaz.MonadError_
 
 import slamdata.Predef.{Stream => _, _}
@@ -34,10 +33,8 @@ import cats.syntax.flatMap._
 import cats.syntax.functor._
 import cats.syntax.option._
 import fs2.Stream
-import org.http4s.Uri
 import org.http4s.client.Client
 import pathy.Path
-import pathy.Path.{DirName, FileName}
 import scalaz.{\/-, -\/}
 import shims._
 

--- a/datasource/src/test/scala/quasar/physical/s3/S3DatasourceSpec.scala
+++ b/datasource/src/test/scala/quasar/physical/s3/S3DatasourceSpec.scala
@@ -51,11 +51,6 @@ class S3DatasourceSpec extends DatasourceSpec[IO, Stream[IO, ?]] {
   val spanishResource = spanishResourcePrefix / spanishResourceLeaf
 
   "pathIsResource" >> {
-    "the root of a bucket with a trailing slash is not a resource" >>* {
-      val root = ResourcePath.root() / ResourceName("")
-      datasource.pathIsResource(root).map(_ must beFalse)
-    }
-
     "the root of a bucket is not a resource" >>* {
       val root = ResourcePath.root()
       datasource.pathIsResource(root).map(_ must beFalse)


### PR DESCRIPTION
It'd be good to have some kind of static guarantee that datasources won't be handed empty `ResourceName`'s. Maybe change [`ResourceName` to use `NonEmptyString` rather than `String`?](https://github.com/slamdata/quasar/blob/master/api/src/main/scala/quasar/api/resource/ResourceName.scala#L24).