### PR TITLE
Add slash at the end of a bucket name when calling HeadBucket. 

### DIFF
--- a/datasource/src/main/scala/quasar/physical/s3/impl/preflightCheck.scala
+++ b/datasource/src/main/scala/quasar/physical/s3/impl/preflightCheck.scala
@@ -49,8 +49,8 @@ object preflightCheck {
     }
 
   private def redirectFor[F[_]: Applicative](client: Client[F], u: Uri)
-      : F[Option[(Status, Uri)]] = {
-    client.fetch(Request[F](uri = u, method = Method.HEAD))(resp => resp.status match {
+      : F[Option[(Status, Uri)]] =
+    client.fetch(Request[F](uri = appendPathS3Encoded(u, ""), method = Method.HEAD))(resp => resp.status match {
       case status @ (MovedPermanently | PermanentRedirect) =>
         resp.headers.get(Location).map(loc => (status, loc.uri)).pure[F]
       case status @ (TemporaryRedirect | Found | SeeOther) =>
@@ -60,5 +60,4 @@ object preflightCheck {
       case _ =>
         none.pure[F]
     })
-  }
 }

--- a/datasource/src/test/scala/quasar/physical/s3/impl/PreflightCheckSpec.scala
+++ b/datasource/src/test/scala/quasar/physical/s3/impl/PreflightCheckSpec.scala
@@ -35,27 +35,27 @@ final class PreflightCheckSpec extends Specification {
 
   val maxRedirects = 3
   val app = HttpRoutes.of[IO] {
-    case Method.HEAD -> Root / "bucket0" =>
-      SeeOther(Location(Uri.uri("http://localhost/bucket1")))
-    case Method.HEAD -> Root / "bucket1" =>
-      MovedPermanently(Location(Uri.uri("http://localhost/bucket2")))
-    case Method.HEAD -> Root / "bucket2" =>
-      PermanentRedirect(Location(Uri.uri("http://localhost/bucket3")))
-    case Method.HEAD -> Root / "bucket3" =>
+    case Method.HEAD -> Root / "bucket0" / "" =>
+      SeeOther(Location(Uri.uri("http://localhost/bucket1/")))
+    case Method.HEAD -> Root / "bucket1" / "" =>
+      MovedPermanently(Location(Uri.uri("http://localhost/bucket2/")))
+    case Method.HEAD -> Root / "bucket2" / "" =>
+      PermanentRedirect(Location(Uri.uri("http://localhost/bucket3/")))
+    case Method.HEAD -> Root / "bucket3" / "" =>
       Ok()
 
-    case Method.HEAD -> Root / "loop0" =>
-      PermanentRedirect(Location(Uri.uri("http://localhost/loop1")))
-    case Method.HEAD -> Root / "loop1" =>
-      PermanentRedirect(Location(Uri.uri("http://localhost/loop0")))
+    case Method.HEAD -> Root / "loop0" / "" =>
+      PermanentRedirect(Location(Uri.uri("http://localhost/loop1/")))
+    case Method.HEAD -> Root / "loop1" / "" =>
+      PermanentRedirect(Location(Uri.uri("http://localhost/loop0/")))
 
-    case Method.HEAD -> Root / "first" =>
-      PermanentRedirect(Location(Uri.uri("http://localhost/second")))
-    case Method.HEAD -> Root / "second" =>
-      PermanentRedirect(Location(Uri.uri("http://localhost/third")))
-    case Method.HEAD -> Root / "third" =>
-      PermanentRedirect(Location(Uri.uri("http://localhost/fourth")))
-    case Method.HEAD -> Root / "fourth" =>
+    case Method.HEAD -> Root / "first" / "" =>
+      PermanentRedirect(Location(Uri.uri("http://localhost/second/")))
+    case Method.HEAD -> Root / "second" / ""  =>
+      PermanentRedirect(Location(Uri.uri("http://localhost/third/")))
+    case Method.HEAD -> Root / "third" / "" =>
+      PermanentRedirect(Location(Uri.uri("http://localhost/fourth/")))
+    case Method.HEAD -> Root / "fourth" / "" =>
       Ok()
   }.orNotFound
 
@@ -63,33 +63,33 @@ final class PreflightCheckSpec extends Specification {
   val config = S3Config(Uri.uri("http://localhost/bucket1"), S3JsonParsing.LineDelimited, None)
 
   "updates bucket URI for permanent redirects" >> {
-    val uri = Uri.uri("http://localhost/bucket2")
-    val redirectedTo = Uri.uri("http://localhost/bucket3")
+    val uri = Uri.uri("http://localhost/bucket2/")
+    val redirectedTo = Uri.uri("http://localhost/bucket3/")
 
     impl.preflightCheck(client, uri, maxRedirects).unsafeRunSync must beSome(redirectedTo)
   }
 
   "bucket URI is not altered for non-permanent redirects" >> {
-    val uri = Uri.uri("http://localhost/bucket0")
+    val uri = Uri.uri("http://localhost/bucket0/")
 
     impl.preflightCheck(client, uri, maxRedirects).unsafeRunSync must beSome(uri)
   }
 
   "bucket URI is not altered for non-redirects" >> {
-    val uri = Uri.uri("http://localhost/bucket3")
+    val uri = Uri.uri("http://localhost/bucket3/")
 
     impl.preflightCheck(client, uri, maxRedirects).unsafeRunSync must beSome(uri)
   }
 
   "follows three permanent redirects" >> {
-    val uri = Uri.uri("http://localhost/first")
-    val finalUri = Uri.uri("http://localhost/fourth")
+    val uri = Uri.uri("http://localhost/first/")
+    val finalUri = Uri.uri("http://localhost/fourth/")
 
     impl.preflightCheck(client, uri, maxRedirects).unsafeRunSync must beSome(finalUri)
   }
 
   "fails with more than three redirects" >> {
-    val uri = Uri.uri("http://localhost/loop0")
+    val uri = Uri.uri("http://localhost/loop0/")
 
     impl.preflightCheck(client, uri, maxRedirects).unsafeRunSync must beNone
   }


### PR DESCRIPTION
AWS signing breaks otherwise. This should fix the listing problems. This still needs tests.