### PR TITLE
Take advantage of delimiter and prefixes to speed up listing

### DIFF
--- a/datasource/src/test/scala/quasar/physical/s3/S3DatasourceSpec.scala
+++ b/datasource/src/test/scala/quasar/physical/s3/S3DatasourceSpec.scala
@@ -87,8 +87,8 @@ class S3DatasourceSpec extends DatasourceSpec[IO, Stream[IO, ?]] {
       assertPrefixedChildPaths(
         ResourcePath.root(),
         List(
-          ResourceName("dir1") -> ResourcePathType.prefix,
           ResourceName("extraSmallZips.data") -> ResourcePathType.leafResource,
+          ResourceName("dir1") -> ResourcePathType.prefix,
           ResourceName("prefix3") -> ResourcePathType.prefix,
           ResourceName("testData") -> ResourcePathType.prefix))
     }

--- a/datasource/src/test/scala/quasar/physical/s3/impl/ChildrenSpec.scala
+++ b/datasource/src/test/scala/quasar/physical/s3/impl/ChildrenSpec.scala
@@ -41,8 +41,8 @@ final class ChildrenSpec extends Specification {
       .getOrElseF(IO.raiseError(new Exception("Could not list children under the root")))
       .flatMap(_.compile.toList).map { children =>
         children.length must_== 4
-        children(0).toEither must_== Left(Path.DirName("dir1"))
-        children(1).toEither must_== Right(Path.FileName("extraSmallZips.data"))
+        children(0).toEither must_== Right(Path.FileName("extraSmallZips.data"))
+        children(1).toEither must_== Left(Path.DirName("dir1"))
         children(2).toEither must_== Left(Path.DirName("prefix3"))
         children(3).toEither must_== Left(Path.DirName("testData"))
       }.unsafeRunSync


### PR DESCRIPTION
After #336 I realized that listing buckets with a large number of files was unusably slow. This fixes it. This is pretty urgent.