### PR TITLE
Use virtualhost style urls

### DIFF
--- a/datasource/src/test/scala/quasar/physical/s3/GzipS3DatasourceSpec.scala
+++ b/datasource/src/test/scala/quasar/physical/s3/GzipS3DatasourceSpec.scala
@@ -31,7 +31,7 @@ import shims._
 final class GzipS3DatasourceSpec extends S3DatasourceSpec {
   import S3DatasourceModule.DS
 
-  override val testBucket = Uri.uri("https://s3.amazonaws.com/slamdata-public-gzip-test")
+  override val testBucket = Uri.uri("https://slamdata-public-gzip-test.s3.amazonaws.com")
 
   override def assertResultBytes(
       ds: DS[IO],

--- a/datasource/src/test/scala/quasar/physical/s3/S3DatasourceModuleSpec.scala
+++ b/datasource/src/test/scala/quasar/physical/s3/S3DatasourceModuleSpec.scala
@@ -39,7 +39,7 @@ class S3DatasourceModuleSpec extends Specification {
   "rejects invalid credentials" >> {
     // slamdata-private-test is a bucket that requires credentials to access
     val conf = Json.obj(
-      "bucket" -> Json.jString("https://s3.amazonaws.com/slamdata-private-test"),
+      "bucket" -> Json.jString("https://slamdata-private-test.s3.amazonaws.com"),
       "jsonParsing" -> Json.jString("array"))
 
     val ds = S3DatasourceModule.lightweightDatasource[IO](conf).unsafeRunSync.toEither

--- a/datasource/src/test/scala/quasar/physical/s3/S3DatasourceSpec.scala
+++ b/datasource/src/test/scala/quasar/physical/s3/S3DatasourceSpec.scala
@@ -45,7 +45,7 @@ class S3DatasourceSpec extends DatasourceSpec[IO, Stream[IO, ?]] {
 
   def iRead[A](path: A): InterpretedRead[A] = InterpretedRead(path, ScalarStages.Id)
 
-  val testBucket = Uri.uri("https://s3.amazonaws.com/slamdata-public-test")
+  val testBucket = Uri.uri("https://slamdata-public-test.s3.amazonaws.com")
   val nonExistentPath =
     ResourcePath.root() / ResourceName("does") / ResourceName("not") / ResourceName("exist")
 

--- a/datasource/src/test/scala/quasar/physical/s3/SecureS3DatasourceSpec.scala
+++ b/datasource/src/test/scala/quasar/physical/s3/SecureS3DatasourceSpec.scala
@@ -36,7 +36,7 @@ import shims._
 import SecureS3DatasourceSpec._
 
 final class SecureS3DatasourceSpec extends S3DatasourceSpec {
-  override val testBucket = Uri.uri("https://s3.amazonaws.com/slamdata-private-test")
+  override val testBucket = Uri.uri("https://slamdata-private-test.s3.amazonaws.com")
 
   override val credentials: IO[Option[S3Credentials]] = {
     val read = IO {

--- a/datasource/src/test/scala/quasar/physical/s3/impl/ChildrenSpec.scala
+++ b/datasource/src/test/scala/quasar/physical/s3/impl/ChildrenSpec.scala
@@ -33,7 +33,7 @@ final class ChildrenSpec extends Specification {
     implicit val cs = IO.contextShift(ExecutionContext.global)
     // Force S3 to return a single element per page in ListObjects,
     // to ensure pagination works correctly
-    val bucket = Uri.uri("https://s3.amazonaws.com/slamdata-public-test/").withQueryParam("max-keys", "1")
+    val bucket = Uri.uri("https://slamdata-public-test.s3.amazonaws.com").withQueryParam("max-keys", "1")
 
     val dir = Path.rootDir
     val client = BlazeClientBuilder[IO](ExecutionContext.global).resource


### PR DESCRIPTION
Use virtualhost style urls 

... path style urls still work but are going to be deprecated
https://aws.amazon.com/blogs/aws/amazon-s3-path-deprecation-plan-the-rest-of-the-story/